### PR TITLE
Rotation fixes

### DIFF
--- a/JTCAdBaseViewController/JTCAdBaseViewController.m
+++ b/JTCAdBaseViewController/JTCAdBaseViewController.m
@@ -303,6 +303,15 @@
             wself.mainViewController.view.frame = rectNew;
         }];
     }
+    if (_isAdRemoved) {
+        __weak JTCAdBaseViewController * wself = self;
+        CGRect rectNew = CGRectMake(0, 0, wself.view.bounds.size.width, wself.view.bounds.size.height);
+        [UIView animateWithDuration:duration animations:^{
+            wself.mainViewController.view.frame = rectNew;
+        } completion:^(BOOL finished) {
+            wself.mainViewController.view.frame = rectNew;
+        }];
+    }
     if ([self.mainViewController respondsToSelector:@selector(adBaseViewController:willChangeFrameTo:duration:)]) {
         [self.mainViewController adBaseViewController:self willChangeFrameTo:self.mainViewController.view.frame.size duration:duration];
     }

--- a/JTCAdBaseViewController/JTCAdBaseViewController.m
+++ b/JTCAdBaseViewController/JTCAdBaseViewController.m
@@ -262,7 +262,9 @@
         __weak JTCAdBaseViewController * wself = self;
         
         CGRect rectNew = CGRectMake(0, headerHeight, wself.view.bounds.size.width, wself.view.bounds.size.height - footerHeight - headerHeight);
+#ifdef DEBUG
         NSLog(@"iAd rectNew size %@", NSStringFromCGRect(rectNew));
+#endif
         
         [UIView animateWithDuration:duration animations:^{
             wself.mainViewController.view.frame = rectNew;
@@ -295,7 +297,9 @@
         __weak JTCAdBaseViewController * wself = self;
         
         CGRect rectNew = CGRectMake(0, headerHeight, wself.view.bounds.size.width, wself.view.bounds.size.height - footerHeight - headerHeight);
+#ifdef DEBUG
         NSLog(@"gAd rectNew size %@", NSStringFromCGRect(rectNew));
+#endif
         
         [UIView animateWithDuration:duration animations:^{
             wself.mainViewController.view.frame = rectNew;

--- a/JTCAdBaseViewController/JTCAdBaseViewController.m
+++ b/JTCAdBaseViewController/JTCAdBaseViewController.m
@@ -225,7 +225,6 @@
 - (void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
     JTC_LOG_METHOD;
     
-    //if (UI_USER_INTERFACE_IDIOM()== UIUserInterfaceIdiomPhone && _iAdBannerView.superview) { // remove ipad
     if (_iAdBannerView.superview) {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
         // If configured to support iOS <6.0, then we need to set the currentContentSizeIdentifier in order to resize the banner properly.
@@ -271,7 +270,6 @@
             wself.mainViewController.view.frame = rectNew;
         }];
     }
-    //if (_gAdBannerView && !_gAdBannerView.superview) { // original - remove the !
     if (_gAdBannerView && _gAdBannerView.superview) {
         CGRect gadRect;
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
@@ -280,15 +278,12 @@
             gadRect.size = kGADAdSizeBanner.size;
         }
         if (_adLocation==JTCAdBaseViewAdLocationBottom) {
-            //gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, CGRectGetMaxY(self.view.bounds)); // add -gad height
             gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, CGRectGetMaxY(self.view.bounds) - gadRect.size.height);
         }else{
-            //gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, - gadRect.size.height); // top is 0 whatever, - height just sends ad above screen
             gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, 0);
         }
         _gAdBannerView.frame = gadRect;
         
-        // test to fix rotation when google ad on screen
         float footerHeight,headerHeight;
         if (_adLocation==JTCAdBaseViewAdLocationBottom) {
             footerHeight = gadRect.size.height;
@@ -307,7 +302,6 @@
         } completion:^(BOOL finished) {
             wself.mainViewController.view.frame = rectNew;
         }];
-        // end test - remove if not making any odds
     }
     if ([self.mainViewController respondsToSelector:@selector(adBaseViewController:willChangeFrameTo:duration:)]) {
         [self.mainViewController adBaseViewController:self willChangeFrameTo:self.mainViewController.view.frame.size duration:duration];

--- a/JTCAdBaseViewController/JTCAdBaseViewController.m
+++ b/JTCAdBaseViewController/JTCAdBaseViewController.m
@@ -225,8 +225,8 @@
 - (void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
     JTC_LOG_METHOD;
     
-
-    if (UI_USER_INTERFACE_IDIOM()== UIUserInterfaceIdiomPhone && _iAdBannerView.superview) {
+    //if (UI_USER_INTERFACE_IDIOM()== UIUserInterfaceIdiomPhone && _iAdBannerView.superview) { // remove ipad
+    if (_iAdBannerView.superview) {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
         // If configured to support iOS <6.0, then we need to set the currentContentSizeIdentifier in order to resize the banner properly.
         // This continues to work on iOS 6.0, so we won't need to do anything further to resize the banner.
@@ -263,18 +263,16 @@
         __weak JTCAdBaseViewController * wself = self;
         
         CGRect rectNew = CGRectMake(0, headerHeight, wself.view.bounds.size.width, wself.view.bounds.size.height - footerHeight - headerHeight);
-        
-        
+        NSLog(@"iAd rectNew size %@", NSStringFromCGRect(rectNew));
         
         [UIView animateWithDuration:duration animations:^{
             wself.mainViewController.view.frame = rectNew;
         } completion:^(BOOL finished) {
             wself.mainViewController.view.frame = rectNew;
         }];
-
-        
     }
-    if (_gAdBannerView && !_gAdBannerView.superview) {
+    //if (_gAdBannerView && !_gAdBannerView.superview) { // original - remove the !
+    if (_gAdBannerView && _gAdBannerView.superview) {
         CGRect gadRect;
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
             gadRect.size = kGADAdSizeFullBanner.size;
@@ -282,11 +280,34 @@
             gadRect.size = kGADAdSizeBanner.size;
         }
         if (_adLocation==JTCAdBaseViewAdLocationBottom) {
-            gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, CGRectGetMaxY(self.view.bounds));
+            //gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, CGRectGetMaxY(self.view.bounds)); // add -gad height
+            gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, CGRectGetMaxY(self.view.bounds) - gadRect.size.height);
         }else{
-            gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, - gadRect.size.height);
+            //gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, - gadRect.size.height); // top is 0 whatever, - height just sends ad above screen
+            gadRect.origin = CGPointMake((self.view.bounds.size.width - gadRect.size.width) / 2, 0);
         }
         _gAdBannerView.frame = gadRect;
+        
+        // test to fix rotation when google ad on screen
+        float footerHeight,headerHeight;
+        if (_adLocation==JTCAdBaseViewAdLocationBottom) {
+            footerHeight = gadRect.size.height;
+            headerHeight = 0;
+        }else{
+            footerHeight = 0;
+            headerHeight = gadRect.size.height;
+        }
+        __weak JTCAdBaseViewController * wself = self;
+        
+        CGRect rectNew = CGRectMake(0, headerHeight, wself.view.bounds.size.width, wself.view.bounds.size.height - footerHeight - headerHeight);
+        NSLog(@"gAd rectNew size %@", NSStringFromCGRect(rectNew));
+        
+        [UIView animateWithDuration:duration animations:^{
+            wself.mainViewController.view.frame = rectNew;
+        } completion:^(BOOL finished) {
+            wself.mainViewController.view.frame = rectNew;
+        }];
+        // end test - remove if not making any odds
     }
     if ([self.mainViewController respondsToSelector:@selector(adBaseViewController:willChangeFrameTo:duration:)]) {
         [self.mainViewController adBaseViewController:self willChangeFrameTo:self.mainViewController.view.frame.size duration:duration];


### PR DESCRIPTION
Thanks for your AdBaseViewController. I've been playing around with it.

After finding the instruction to add -ObjC to the Other Linker Flags of your application target's build setting, everything began to work. I think you should add that to the set-up instructions. It's easy to miss if you don't read Google's AdMob instructions as well.

I was testing out rotation and it was working fine with iAds but not with gAds. So I decided to try to fix it and my changes are in the commits.

I've added changes to willAnimateRotationToInterfaceOrientation to fix positioning of GADs when rotation occurs and to make the main view resize correctly too as it does for iAds.

It seems to work on iPad & iPhone 5.1 + 6.0 when autoLayout is off on the storyboard.

Hope the changes are helpful. This is my first open source pull request. I hope I've done it ok!
